### PR TITLE
Use libedit instead of readline

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,7 @@ RUN apk add \
         flex \
         git \
         krb5-dev \
-        # TODO: Make meson find this instead of readline \
-        #libedit-dev \
+        libedit-dev \
         libxml2-dev \
         libxslt-dev \
         linux-headers \
@@ -28,7 +27,6 @@ RUN apk add \
         perl-lwp-protocol-https \
         perl-mozilla-ca \
         python3-dev \
-        readline-dev \
         tcl-dev \
         zlib-dev \
         zstd-dev

--- a/meson.conf
+++ b/meson.conf
@@ -13,6 +13,9 @@ push(@{@PGBuild::conf{meson_opts}}, (
 	'-Dzstd=enabled'
 ));
 
+# TODO: This should not be required, fix upstream.
+push(@{@PGBuild::conf{meson_opts}}, '-Dlibedit_preferred=true');
+
 # TODO: Building with --enable-nls currently fails with:
 # ld: ../../src/port/libpgport.a(strerror.o): in function `pg_strerror_r':
 # src/port/strerror.c:72:(.text+0x260): undefined reference to `libintl_gettext'


### PR DESCRIPTION
libedit is a drop-in replacement for readline, but meson can't find it.